### PR TITLE
Allow configuring API worker count to improve Forecasting API latency

### DIFF
--- a/src/relife_forecasting/__init__.py
+++ b/src/relife_forecasting/__init__.py
@@ -3,9 +3,19 @@ import os
 import uvicorn
 
 
+def get_worker_count() -> int:
+    raw_value = os.getenv("API_WORKERS", "1")
+
+    try:
+        return max(1, int(raw_value))
+    except ValueError as exc:
+        raise ValueError("API_WORKERS must be a positive integer.") from exc
+
+
 def main() -> None:
     host = os.getenv("API_HOST", "0.0.0.0")
     port = int(os.getenv("API_PORT", 9090))
+    workers = get_worker_count()
     # Dynamically determine the module path
     module_name = __name__.split(".")[0]
-    uvicorn.run(f"{module_name}.main:app", host=host, port=port)
+    uvicorn.run(f"{module_name}.main:app", host=host, port=port, workers=workers)


### PR DESCRIPTION
## Summary

This change makes the Forecasting API worker count configurable through the `API_WORKERS` environment variable.

By default, the service still runs with `1` worker, so existing behavior is preserved unless deployment explicitly opts in to a higher worker count.

## Why

The `/simulate` and `/ecm_application` endpoints are slow and CPU-heavy. Running the service with a single worker makes concurrent requests queue behind each other, which increases user-perceived latency in PRA and HRA.

This PR keeps the service API and request/response data models untouched and only adds a deployment-time concurrency configuration value.

## Validation

Local smoke testing against the integrated stack showed clear improvement when increasing workers:

- 2-worker run: concurrent/sequential ratio about `0.51`
- 4-worker run (`x2` load): concurrent/sequential ratio about `0.50`
- 4-worker run (`x4` load): concurrent/sequential ratio about `0.26`